### PR TITLE
use match syntax that works in pre 2.4 ruby

### DIFF
--- a/lib/search-and-replace.rb
+++ b/lib/search-and-replace.rb
@@ -22,7 +22,7 @@ class SearchAndReplace
 
   # Determines if string is regexp and converts to object if so
   def pattern(string, options: nil)
-    %r{^/.*/$}.match?(string) ? Regexp.new(string[1..-2], options) : string
+    !%r{^/.*/$}.match(string).nil? ? Regexp.new(string[1..-2], options) : string
   end
 
   def parse_files


### PR DESCRIPTION
OS X's 10.15's default ruby is still 2.3. Sourcetree (GUI git client I use) uses the system ruby to run pre-commit and the 'match?' syntax explodes. This fixes the issue.

Fix from https://github.com/teohm/git-chlog/pull/7.