### PR TITLE
add color to output, show match length and replacement if specified

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,8 @@ repos:
           - --fix
         exclude: Gemfile.lock
         stages: [commit]
+      - id: rspec
+        stages: [commit]
   - repo: https://github.com/mattlqx/pre-commit-sign
     rev: v1.2.0
     hooks:

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'mixlib-shellout', '~> 3.2'
+gem 'rainbow'
 gem 'rspec'
 gem 'rubocop', '~> 1.62'
 gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ PLATFORMS
 
 DEPENDENCIES
   mixlib-shellout (~> 3.2)
+  rainbow
   rspec
   rubocop (~> 1.62)
   simplecov

--- a/bin/search-and-replace.rb
+++ b/bin/search-and-replace.rb
@@ -2,32 +2,31 @@
 # frozen_string_literal: true
 
 require 'optparse'
+require 'rainbow'
 require 'yaml'
 
 require_relative '../lib/search-and-replace'
 
-command_opts = {}
+command_opts = {
+  :color => true,
+  :write => true,
+  :config => '.pre-commit-search-and-replace.yaml'
+}
 op = OptionParser.new do |opts|
   opts.banner = "Usage: #{$PROGRAM_NAME} <args> <files>"
 
-  opts.on('-c', '--config PATH', 'YAML config for multiple search and, optionally, replace operations') do |v|
-    command_opts['config'] = v
-  end
-  opts.on('-s', '--search STRING', 'Search string or regexp (required if not using config)') do |v|
-    command_opts['search'] = v
-  end
-  opts.on('-r', '--replacement STRING', 'Replacement string') do |v|
-    command_opts['replacement'] = v
-  end
-  opts.on('-i', '--[no-]insensitive', 'Case-insensitive search') do |v|
-    command_opts['insensitive'] = v
-  end
-  opts.on('-e', '--[no-]extended', 'Extended regexp search') do |v|
-    command_opts['extended'] = v
-  end
+  opts.on('-c', '--config PATH',
+          'YAML config for multiple search and, optionally, replace operations. ' \
+          'default .pre-commit-search-and-replace.yaml')
+  opts.on('-s', '--search STRING', 'Search string or regexp (required if not using config)')
+  opts.on('-r', '--replacement STRING', 'Replacement string')
+  opts.on('-i', '--[no-]insensitive', 'Case-insensitive search')
+  opts.on('-e', '--[no-]extended', 'Extended regexp search')
+  opts.on('-C', '--[no-]color', 'Output coloring, default true')
+  opts.on('-w', '--[no-]write', 'Write replacements to file, default true')
 end
-op.parse!
-command_opts['config'] ||= '.pre-commit-search-and-replace.yaml'
+op.parse!(into: command_opts)
+Rainbow.enabled = command_opts[:color]
 
 if ARGV.length.zero?
   $stderr.write("No files to search supplied as arguments!\n")
@@ -35,15 +34,15 @@ if ARGV.length.zero?
   exit(1)
 end
 
-ARGV.reject! { |f| File.absolute_path(f) == File.absolute_path(command_opts['config']) }
+ARGV.reject! { |f| File.absolute_path(f) == File.absolute_path(command_opts[:config]) }
 
-configs = if command_opts['search']
+configs = if command_opts[:search]
             [command_opts]
           else
             begin
-              YAML.safe_load(IO.read(command_opts['config']))
+              YAML.safe_load(IO.read(command_opts[:config]))
             rescue Errno::ENOENT
-              $stderr.write("Unable to open #{command_opts['config']} and no search argument specified.\n")
+              $stderr.write("Unable to open #{command_opts[:config]} and no search argument specified.\n")
               puts "\n#{op.help}"
               exit(1)
             end
@@ -53,30 +52,34 @@ exit_status = 0
 
 # Process each entry in the config against all arguments (filenames)
 configs.each_with_index do |entry, i|
-  puts "Config entry #{i + 1} is missing required search string." && exit(1) if entry['search'].nil?
+  entry.transform_keys!(&:to_sym)
+  puts "Config entry #{i + 1} is missing required search string." && exit(1) if entry[:search].nil?
   sar = SearchAndReplace.from_config(ARGV, entry)
   sar.parse_files.each do |result|
     next if result.empty?
 
-    puts "==== Found #{result.length} occurrences of \"#{entry['description'] || entry['search']}\" in " \
-         "#{result.first.file}:\n\n"
+    puts "==== Found #{Rainbow(result.length).red} occurrences of " \
+         "\"#{Rainbow(entry[:description] || entry[:search]).yellow}\" in " \
+         "#{Rainbow(result.first.file).cyan}:\n\n"
     puts result.occurrences.map(&:to_s).join("\n")
     exit_status = 1
-    next if entry['replacement'].nil?
+    next if entry[:replacement].nil?
 
-    files_fixed << result.first.file
+    if command_opts[:write]
+      files_fixed << result.first.file
 
-    src = result.replacement_file_path
-    dest = result.first.file
+      src = result.replacement_file_path
+      dest = result.first.file
 
-    unless RUBY_PLATFORM =~ /mswin|mingw|windows/
-      stat = File.stat(dest)
-      FileUtils.chown(stat.uid, stat.gid, src)
-      FileUtils.chmod(stat.mode, src)
+      unless RUBY_PLATFORM =~ /mswin|mingw|windows/
+        stat = File.stat(dest)
+        FileUtils.chown(stat.uid, stat.gid, src)
+        FileUtils.chmod(stat.mode, src)
+      end
+      FileUtils.mv(src, dest)
     end
-    FileUtils.mv(src, dest)
   end
 end
 
-files_fixed.uniq.each { |dest| puts "Fixed #{dest}" }
+files_fixed.uniq.each { |dest| puts Rainbow("Fixed #{dest}").green }
 exit(exit_status)


### PR DESCRIPTION
Fixes #11 

Colorizes the output some to make it more readable.

I also did some work to make the output display the length of the match and another block to show what the line is changing to.

<img width="805" alt="Screenshot 2024-03-24 at 11 27 58" src="https://github.com/mattlqx/pre-commit-search-and-replace/assets/739851/650f04f0-5a3e-4d68-ac97-fdc0f9fb5971">
