### PR TITLE
Add more stypes to no-search-replace exclude

### DIFF
--- a/lib/search-and-replace.rb
+++ b/lib/search-and-replace.rb
@@ -58,7 +58,7 @@ class SearchAndReplace
     offset = 0
     match = false
     until match.nil?
-      if line.index(%r{(//|#)\s*no-search-replace})
+      if line.index(%r{(//|//*|#|<!--)\s*no-search-replace})
         match = nil
       elsif @search_opts & Regexp::IGNORECASE == Regexp::IGNORECASE && @search.is_a?(String)
         match = line.downcase.index(@search.downcase, offset)

--- a/lib/search-and-replace.rb
+++ b/lib/search-and-replace.rb
@@ -58,7 +58,7 @@ class SearchAndReplace
     offset = 0
     match = false
     until match.nil?
-      if line.index(%r{(//|//*|#|<!--)\s*no-search-replace})
+      if line.index(%r{(//|/*|#|<!--)\s*no-search-replace})
         match = nil
       elsif @search_opts & Regexp::IGNORECASE == Regexp::IGNORECASE && @search.is_a?(String)
         match = line.downcase.index(@search.downcase, offset)


### PR DESCRIPTION
This adds more comment styles to in. Maybe we could even think about being independent of the comment symbol, but introduce a special prefix as done for other tools such as `nolint: no-search-replace` or `noqa: no-search-replace` or `ignore: no-search-replace`