### PR TITLE
fix replacements with references

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a plugin for [pre-commit](https://pre-commit.com) that will run search a
 By default, a YAML config file is loaded at `.pre-commit-search-and-replace.yaml` in the root of the repo. This config file should be a list of entries specifying any of the following keys:
 
 - `search`: (required) the string or regexp to search for. To use a regexp, start and end with slashes. e.g. `/^mypattern/`
-- `replacement`: the string to replace matched strings with. If specified, files will "fixed". Match groups can be referenced here (e.g. `\1`)
+- `replacement`: the string to replace matched strings with. If specified, files will "fixed". Match groups can be referenced here (e.g. `\1` or `\k<foo>`)
 - `insensitive`: boolean whether the regexp should be case-insensitive. default: `false`
 - `extended`: boolean whether the regexp should be extended. default: `false`
 - `description`: short text description of purpose of the entry.

--- a/spec/unit/fixtures/search-and-replace.yaml
+++ b/spec/unit/fixtures/search-and-replace.yaml
@@ -16,3 +16,6 @@
 - search: /( *\/\/\/ +([@\\]param)) +(\w+) *(\[(in|out|in, *out)\])?/
   replacement: \1\4 \3
   description: "Fix malformed Doxygen param in/out syntax"
+- search: "/Here's one: (?<what>[a-z]+)/"
+  replacement: It is \k<what>
+  description: Named capture replacement


### PR DESCRIPTION
There was an issue with replacements with back-references as the implementation of determining if a string was a regex was to create a Regexp object with a named capture. This overrode the inner matching of the pattern string.

To fix, we convert the replacement string as is. That fixed replacements, but then we also have to adjust how we evaluate the replacement string as that gets used to determine the length of highlighting.

<img width="795" alt="Screenshot 2024-09-27 at 10 50 59" src="https://github.com/user-attachments/assets/9e9447f3-ff73-4539-a4fa-6f5caf6a8edd">

Fixes #22 