### PR TITLE
Pin default ruby version

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
   description: Search and replace strings
   entry: search-and-replace
   language: ruby
-  language_version: 2.2.7
+  language_version: 2.7.2
   pass_filenames: true
   exclude_types:
     - binary

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+  ruby: 2.2.7
 - id: search-and-replace
   name: Search and replace strings
   description: Search and replace strings

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,9 @@
-default_language_version:
-  ruby: 2.2.7
 - id: search-and-replace
   name: Search and replace strings
   description: Search and replace strings
   entry: search-and-replace
   language: ruby
+  language_version: 2.2.7
   pass_filenames: true
   exclude_types:
     - binary


### PR DESCRIPTION
Probably related to https://github.com/PlasmaPy/PlasmaPy/pull/2455. To reproduce, you can go into docker container

```dockerfile
# syntax = docker/dockerfile:1.2

FROM ubuntu:22.04

ENV DEBIAN_FRONTEND noninteractive

RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
    apt-get update && \
    apt-get install -y --no-install-recommends --allow-change-held-packages --allow-downgrades \
    build-essential \
    ca-certificates \
    gnupg \
    libc++-dev \
    lsb-release \
    git \
    python3.10-venv \
    python3-dev \
    python3-pip \
    software-properties-common \
    sudo \
    wget && \
    rm -rf /var/lib/apt/lists/*

WORKDIR /tmp

# Create non-root user
ARG user_id=1000
ARG group_id="${user_id}"
ARG username="your_name"

# Add user and group that match the uids of the current running user.
RUN groupadd --gid "${group_id}" "${username}" \
    && useradd --create-home --shell /bin/bash --no-log-init --uid "${user_id}" --gid "${group_id}" "${username}" \
    && usermod -aG sudo "${username}" \
    && echo "${username} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

USER "${user_id}"

RUN pip install pre-commit
ENV HOME /home/"${username}"
ENV PATH="${HOME}/.local/bin:${PATH}"

RUN git config --global user.email "you@example.com"
RUN git config --global user.name "Your Name"

WORKDIR ${HOME}
CMD ["/bin/bash"]
```

and from a repo with pre-commit config

```yaml
repos:
  - repo: https://github.com/mattlqx/pre-commit-search-and-replace
    rev: v1.1.3
    hooks:
    - id: search-and-replace
```

I get the below upon committing

```shell
$ git commit -am "test commit"
[INFO] Initializing environment for https://github.com/mattlqx/pre-commit-search-and-replace.
[INFO] Installing environment for https://github.com/mattlqx/pre-commit-search-and-replace.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('gem', 'build', 'pre-commit-search-and-replace.gemspec')
return code: 1
stdout:
    Executable `gem` not found
stderr: (none)
Check the log at /home/your_name/.cache/pre-commit/pre-commit.log
```

When instead of pointing to `v1.1.3`, I point to this commit in my `.pre-commit-config.yaml`, it works just fine. I don't understand why this fixes it, getting independent of the exact ruby version would be great. Currently, this at least improves the situation.