### PR TITLE
Update search-and-replace hook to latest release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,6 @@ repos:
     hooks:
       - id: sign-commit
   - repo: .
-    rev: b3b69a9079a33a58b660fa9fe31a78600c591b8e
+    rev: v1.1.6
     hooks:
       - id: search-and-replace


### PR DESCRIPTION
This should reproduce [the issue](https://github.com/mattlqx/pre-commit-search-and-replace/issues/32) of the latest release:

```shell
An error has occurred: InvalidManifestError:
==> File ~/.cache/pre-commit/repo34e_dvfr/.pre-commit-hooks.yaml
==> At Hook(id='search-and-replace')
==> At key: language_version
=====> Expected string got float
```