### PR TITLE
add check for empty replacement

### DIFF
--- a/lib/search-and-replace.rb
+++ b/lib/search-and-replace.rb
@@ -76,11 +76,14 @@ class SearchAndReplace
         offset = match + 2
       elsif match.is_a?(MatchData)
         offset = match.begin(0) + 2
-        match.captures.each_with_index do |m, idx|
-          actual_replacement.gsub!("\\#{idx+1}", m)
-        end
-        match.named_captures.each do |name, m|
-          actual_replacement.gsub!("\\k<#{name}>", m)
+
+        unless actual_replacement.nil?
+            match.captures.each_with_index do |m, idx|
+              actual_replacement.gsub!("\\#{idx+1}", m)
+            end
+            match.named_captures.each do |name, m|
+              actual_replacement.gsub!("\\k<#{name}>", m)
+            end
         end
       end
 

--- a/spec/unit/fixtures/bad_content.txt
+++ b/spec/unit/fixtures/bad_content.txt
@@ -15,3 +15,6 @@ How about InsensitiveRegexp?
 /// @param  second  [out] Second param desc
 /// \param  OTHER[out]  Yet another param desc! @param over [in] here too.
 void foo(const some_param_P1 p1, OTHER other);
+
+
+This is FORBIDDEN text.

--- a/spec/unit/fixtures/search-and-replace.yaml
+++ b/spec/unit/fixtures/search-and-replace.yaml
@@ -19,3 +19,5 @@
 - search: "/Here's one: (?<what>[a-z]+)/"
   replacement: It is \k<what>
   description: Named capture replacement
+- search: /(FORBIDDEN)/
+  description: This search uses capture group without replacement

--- a/spec/unit/search_and_replace_spec.rb
+++ b/spec/unit/search_and_replace_spec.rb
@@ -32,6 +32,7 @@ describe SearchAndReplace do
         'ignored double slash comment' => yaml[6],
         'doxygen' => yaml[7],
         'named capture' => yaml[8],
+        'capture group search' => yaml[9],
       }
     end
 
@@ -123,6 +124,13 @@ describe SearchAndReplace do
       expect(sar.call(configs['named capture']).parse_files[0]).to be_a(SearchAndReplace::FileMatches)
       expect(sar.call(configs['named capture']).parse_files[0].length).to eq(1)
       expect(sar.call(configs['named capture']).parse_files[0].occurrences[0].replacement).to eq("It is foobar")
+    end
+
+    it 'has correct number of occurrences for capture group search config' do
+      expect(sar.call(configs['capture group search']).parse_files[0]).to be_a(SearchAndReplace::FileMatches)
+      expect(sar.call(configs['capture group search']).parse_files[0].length).to eq(1)
+      expect(sar.call(configs['capture group search']).parse_files[1]).to be_a(SearchAndReplace::FileMatches)
+      expect(sar.call(configs['capture group search']).parse_files[1].empty?).to be true
     end
   end
 


### PR DESCRIPTION
Code add check for empty value for replacement.

I tested this version together with my local code. There is no error. Regex still matches invalid data.

closes #36